### PR TITLE
Fixed keymap conflicts with the defaults ('toggle_regex' and 'toggle_case_sensitive')

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,6 +1,14 @@
 [
-    { "keys": ["alt+r"], "command": "php_namespace_clean" },
-    { "keys": ["alt+c"], "command": "php_namespace_copy" },
+    { "keys": ["alt+r"], "command": "php_namespace_clean", "context":
+        [
+            { "key": "setting.is_widget", "operator": "equal", "operand": false }
+        ]
+    },
+    { "keys": ["alt+c"], "command": "php_namespace_copy", "context":
+        [
+            { "key": "setting.is_widget", "operator": "equal", "operand": false }
+        ]
+    },
     { "keys": ["alt+u"], "command": "php_namespace_insert_use" },
     { "keys": ["alt+i"], "command": "php_namespace_insert_namespace" },
     { "keys": ["alt+e"], "command": "php_namespace_extend" }

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,6 +1,14 @@
 [
-    { "keys": ["alt+r"], "command": "php_namespace_clean" },
-    { "keys": ["alt+c"], "command": "php_namespace_copy" },
+    { "keys": ["alt+r"], "command": "php_namespace_clean", "context":
+        [
+            { "key": "setting.is_widget", "operator": "equal", "operand": false }
+        ]
+    },
+    { "keys": ["alt+c"], "command": "php_namespace_copy", "context":
+        [
+            { "key": "setting.is_widget", "operator": "equal", "operand": false }
+        ]
+    },
     { "keys": ["alt+u"], "command": "php_namespace_insert_use" },
     { "keys": ["alt+i"], "command": "php_namespace_insert_namespace" },
     { "keys": ["alt+e"], "command": "php_namespace_extend" }


### PR DESCRIPTION
Problem: `alt+r`, `alt+c` bindings reserved by default actions 'Toggle regex' and 'Toggle Case Sensitive' actions in the search pane.

I changed context of `alt+r` and `alt+c`, so PhpNamespace commands would not block the default ones, while search pane is open.
