### PR TITLE
Add support for PSR-4 prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,21 @@ Default shortcut : `alt+u`
 ```
 
 The `php_namespace.stop_folders` setting is used for `php_namespace_insert_namespace` command. It defines the folders where the namespace building has to stop.
+
+### PSR-4
+
+> This setting requires the use of the Sublime Text project feature.
+
+In order to have your namespace generated following a PSR-4 convention, add the following entry to your project settings (`Project` > `Edit Project`) :
+
+```
+{
+    …
+    "psr-4":
+    {
+        "src": "Acme\\"
+    }
+}
+```
+
+The scheme follows the one found in a classical `composer.json`.

--- a/namespaces.py
+++ b/namespaces.py
@@ -19,11 +19,13 @@ def get_namespace(window):
 def build_namespace(view):
     settings = view.settings()
     limits = settings.get('php_namespace.stop_folders')
+    projectPsr = view.window().project_data().get('psr-4', {})
     folders = view.file_name().split(os.sep)
     for limit in limits:
         if limit in folders:
             folders = folders[folders.index(limit):]
-    return "\\".join(folders[1:-1])
+            prefix = projectPsr.get(limit, '')
+    return prefix+"\\".join(folders[1:-1])
 
 # Find all regions situate before class declaration
 def find_all_use_regions(view):


### PR DESCRIPTION
Should fix https://github.com/gl3n/sublime-php-namespace/issues/9

Fetching `composer.json` settings would have been better but my knowledge in Sublime Text API and python limited me.
